### PR TITLE
Create a Remark entity and add a list of remarks to Person class

### DIFF
--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -2,10 +2,13 @@ package seedu.address.model.person;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.model.person.exceptions.RemarksExceedLengthException;
+
 /**
  * Represents a Person in the address book.
  * Guarantees: details are present and not null, field values are validated, immutable.
@@ -20,7 +23,7 @@ public class Person {
     private final TGroup tGroup;
     private final Tele tele;
     private final Progress progress;
-    private String remarks;
+    private final List<Remark> remarks;
 
     /**
      * Every field must be present and not null.
@@ -35,7 +38,7 @@ public class Person {
         this.tGroup = tGroup;
         this.tele = tele;
         this.progress = progress;
-        this.remarks = "";
+        this.remarks = new ArrayList<>();
     }
 
     public Name getName() {
@@ -66,24 +69,30 @@ public class Person {
         return progress;
     }
 
-    public String getRemarks() {
-        return remarks;
+    /**
+     * Returns an unmodifiable view of the remarks list.
+     */
+    public List<Remark> getRemarks() {
+        return Collections.unmodifiableList(remarks);
     }
 
-    public void setRemarks(String remarks) {
-        if (remarks == null) {
-            throw new IllegalArgumentException("Remarks cannot be null");
-        }
-        if (remarks.length() > 100) {
-            throw new RemarksExceedLengthException("Remarks cannot exceed 100 characters");
-        }
-        this.remarks = remarks;
+    /**
+     * Adds a remark to this person.
+     */
+    public void addRemark(Remark remark) {
+        requireAllNonNull(remark);
+        remarks.add(remark);
     }
 
-    public void deleteRemarks() {
-        this.remarks = "";
+    /**
+     * Deletes a remark from this person.
+     *
+     * @return true if the remark was found and removed
+     */
+    public boolean deleteRemark(Remark remark) {
+        requireAllNonNull(remark);
+        return remarks.remove(remark);
     }
-
     /**
      * Returns true if both persons have the same name.
      * This defines a weaker notion of equality between two persons.
@@ -116,13 +125,14 @@ public class Person {
         return studentId.equals(otherPerson.studentId)
                 && Objects.equals(otherPerson.getTele(), getTele())
                 && otherPerson.getEmail().equals(getEmail())
-                && otherPerson.getProgress().equals(getProgress());
+                && otherPerson.getProgress().equals(getProgress())
+                && remarks.equals(otherPerson.remarks);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, courseId, email, studentId, tGroup, tele, progress);
+        return Objects.hash(name, courseId, email, studentId, tGroup, tele, progress, remarks);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Remark.java
+++ b/src/main/java/seedu/address/model/person/Remark.java
@@ -1,0 +1,76 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+/**
+ * Represents a Remark attached to a Person.
+ * Guarantees: immutable; fields are present and valid.
+ */
+public class Remark {
+
+    public static final String MESSAGE_TEXT_CONSTRAINTS =
+            "Remark text must not be null and must not exceed 100 characters.";
+
+    public static final int MAX_LENGTH = 100;
+
+    private final String text;
+    private final LocalDate date;
+
+    /**
+     * Constructs a {@code Remark}.
+     *
+     * @param text The remark text.
+     * @param date The remark date.
+     */
+    public Remark(String text, LocalDate date) {
+        requireNonNull(text);
+        requireNonNull(date);
+        checkArgument(isValidText(text), MESSAGE_TEXT_CONSTRAINTS);
+        this.text = text;
+        this.date = date;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    /**
+     * Returns true if the remark text is valid.
+     */
+    public static boolean isValidText(String text) {
+        return text != null && text.length() <= MAX_LENGTH;
+    }
+
+    @Override
+    public String toString() {
+        return "[" + date + "] " + text;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof Remark)) {
+            return false;
+        }
+
+        Remark otherRemark = (Remark) other;
+        return text.equals(otherRemark.text)
+                && date.equals(otherRemark.date);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(text, date);
+    }
+}

--- a/src/test/java/seedu/address/model/person/RemarkTest.java
+++ b/src/test/java/seedu/address/model/person/RemarkTest.java
@@ -1,0 +1,77 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+
+public class RemarkTest {
+
+    @Test
+    public void constructor_nullText_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Remark(null, LocalDate.of(2025, 10, 1)));
+    }
+
+    @Test
+    public void constructor_nullDate_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Remark("Needs follow-up", null));
+    }
+
+    @Test
+    public void constructor_textTooLong_throwsIllegalArgumentException() {
+        String longText = "a".repeat(101);
+        assertThrows(IllegalArgumentException.class, () -> new Remark(longText, LocalDate.of(2025, 10, 1)));
+    }
+
+    @Test
+    public void isValidText() {
+        assertFalse(Remark.isValidText(null));
+        assertTrue(Remark.isValidText(""));
+        assertTrue(Remark.isValidText("Good progress"));
+        assertTrue(Remark.isValidText("a".repeat(100)));
+        assertFalse(Remark.isValidText("a".repeat(101)));
+    }
+
+    @Test
+    public void constructor_validRemark_success() {
+        LocalDate date = LocalDate.of(2025, 10, 1);
+        Remark remark = new Remark("Consulted student about milestone", date);
+
+        assertEquals("Consulted student about milestone", remark.getText());
+        assertEquals(date, remark.getDate());
+    }
+
+    @Test
+    public void equals() {
+        Remark first = new Remark("Good participation", LocalDate.of(2025, 10, 1));
+        Remark same = new Remark("Good participation", LocalDate.of(2025, 10, 1));
+        Remark differentText = new Remark("Needs follow-up", LocalDate.of(2025, 10, 1));
+        Remark differentDate = new Remark("Good participation", LocalDate.of(2025, 10, 2));
+
+        assertEquals(first, first);
+        assertEquals(first, same);
+        assertNotEquals(first, differentText);
+        assertNotEquals(first, differentDate);
+        assertNotEquals(first, null);
+        assertNotEquals(first, 1);
+    }
+
+    @Test
+    public void hashCode_sameValues_sameHashCode() {
+        Remark first = new Remark("Good participation", LocalDate.of(2025, 10, 1));
+        Remark same = new Remark("Good participation", LocalDate.of(2025, 10, 1));
+
+        assertEquals(first.hashCode(), same.hashCode());
+    }
+
+    @Test
+    public void toString_validRemark_returnsFormattedString() {
+        Remark remark = new Remark("Met during consultation", LocalDate.of(2025, 10, 1));
+        assertEquals("[2025-10-01] Met during consultation", remark.toString());
+    }
+}


### PR DESCRIPTION
Previously, remark was stored as a String.

Change to a Remark class where each Remark object has a String text and date attached to it.
This follows OOP and current AB3 design better.It also supports the TA to enter more than one remark on different dates for a particular student

Closes #109 